### PR TITLE
ARGG-945 Publish package as public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Publish NPM package
         run: |
           npm version $RELEASE_VERSION --no-git-tag-version
-          npm publish
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_VERSION: ${{ github.event.release.tag_name }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,6 @@
 prettier.config.js
 lint-staged.config.js
 eslint.config.js
+.github
+.husky
+.nvmrc


### PR DESCRIPTION
What:
- Publish package as public
- Ignore some more files during publishing

Why:
- This package should be public and not being so requires paid access to npmjs, which we don't have.