### PR TITLE
Add no-jira-ticket rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,12 @@
 
 const noAxios = require('./src/rules/no-axios/no-axios');
 const forbidComponentProps = require('./src/rules/forbid-component-props/forbid-component-props');
+const noJiraTodo = require('./src/rules/no-jira-todo/no-jira-todo');
 
 module.exports = {
   rules: {
     'no-axios': noAxios,
     'forbid-component-props': forbidComponentProps,
+    'no-jira-todo': noJiraTodo,
   },
 };

--- a/src/rules/no-jira-todo/README.md
+++ b/src/rules/no-jira-todo/README.md
@@ -1,0 +1,40 @@
+## Asserting all TODO comments have a linked JIRA ticket
+
+This rule when enabled would require every `TODO` style comnent to be linked to an associated JIRA ticket.
+
+The format of the comment is required to match:
+
+- `TODO:`/`FIXME:`/`@TODO:`/`@FIXME:`
+- followed by the Jira url or the ticket reference in square brackets, eg:
+  - `https://skyscanner.atlassian.net/browse/JIRA-0000`
+  - `[JIRA-0000]`
+- then an optional description about the changes needed by the linked ticket
+
+Examples of valid comments:
+
+```tsx
+// TODO: [WALL-1234] description of the change needed
+// FIXME: [CASTLE-5678]
+// FIXME: [WOM-2468] comment
+// @TODO: [WALL-1234] description of the change needed
+// @FIXME: [WALL-1234] description of the change needed
+// TODO: https://skyscanner.atlassian.net/browse/SHIBA-1234 description of the change needed
+// @FIXME: https://skyscanner.atlassian.net/browse/WOODPECKER-1010 description of the change needed
+// TODO: [JIRA-XXXX] fixed
+```
+
+Examples of invalid comments:
+
+```tsx
+// TODO: WALL-1234 description of the change needed
+// TODO: description of the change needed
+// FIXME description of the change needed WALL-1234
+// @FIXME description of the change needed WALL-1234
+// @TODO: https://skyscanner.atlassian.net/browse/not-a-ticket
+```
+
+If an invalid `TODO` comment is recognised, there is a auto fix available to update the comment to the format. This should be updated with the ticket and description. This is provided in the format:
+
+```tsx
+// TODO: [JIRA-XXX]
+```

--- a/src/rules/no-jira-todo/no-jira-todo.js
+++ b/src/rules/no-jira-todo/no-jira-todo.js
@@ -27,7 +27,8 @@ Maintaining a list of components and managing contributors confusion is higher t
 // ------------------------------------------------------------------------------
 
 const messages = {
-  'todo-error': 'All TODO comments must have a JIRA ticket',
+  'todo-error':
+    'JIRA ticket numbers must be added to all TODO/FIXME comments (e.g. TODO: DINGO-123)',
 };
 
 const verifyCommentPrefix = (comment) =>
@@ -54,12 +55,14 @@ module.exports = {
         const prefix = new RegExp('@?(TODO|FIXME)');
         const ticket = new RegExp('[A-Z]{2,255}-(\\d|X){2,8}');
         const jiraUrl = new RegExp(
-          `https://skyscanner.atlassian.net/browse/${ticket.source}`,
+          `https://([a-zA-Z0-9.\/-]\+)/${ticket.source}`,
         );
         const regex = new RegExp(
-          `${prefix.source}:\\s(${jiraUrl.source}|\\[${ticket.source}\\])(\\s.*)?`,
+          `${prefix.source}:\\s(${jiraUrl.source}|\\[\?${ticket.source}\\]\?)(\\s.*)?`,
           'g',
         );
+
+        console.log({ regex });
 
         for (const comment of context.getSourceCode().getAllComments()) {
           const value = comment.value.trimStart();

--- a/src/rules/no-jira-todo/no-jira-todo.js
+++ b/src/rules/no-jira-todo/no-jira-todo.js
@@ -51,7 +51,6 @@ module.exports = {
         );
         const regex = new RegExp(
           `${prefix.source}:\\s(${jiraUrl.source}|\\[\?${ticket.source}\\]\?)(\\s.*)?`,
-          'g',
         );
 
         for (const comment of context.getSourceCode().getAllComments()) {

--- a/src/rules/no-jira-todo/no-jira-todo.js
+++ b/src/rules/no-jira-todo/no-jira-todo.js
@@ -1,26 +1,18 @@
-/*
-# What is this?
-
-Builds on eslint-plugin-react/forbid-component-props and extends to allow and Allow List to be provided as a regex.
-
-Aside from providing an `allowedForRegex` option the implementation remains the same. A `disallowedForRegex` is not provided as no use case currently exists, so we avoid the extra complexity.
-
-https://github.com/jsx-eslint/eslint-plugin-react/blob/9f4b2b96d92bf61ae61e8fc88c413331efe6f0da/lib/rules/forbid-component-props.js#L2
-
-An issue has been raised with eslint-plugin-react to ask for this feature, if provided we should switch to:
-- https://github.com/jsx-eslint/eslint-plugin-react/issues/3686
-
-
-# Why do we need a custom rule?
-
-We use this linting specifically for linting on className usage. This has been seen to cause specificity problems when working in a code-split app.
-
-Our allowlist for the medium to long term will include Bpk* components, and backpack-component-icon Icons. The former is a static list, which could be maintained in an .eslintrc with minimum toil.
-
-However, when used with the `withDefaultProps` HOC that Backpack provide the names become more dynamic and more toil to maintain. Additionally, and significantly, Icons are also much higher volume, and have dynamic names.
-
-Maintaining a list of components and managing contributors confusion is higher toil than maintaining this custom rule.
-*/
+/**
+ * Copyright 2023-present Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -61,8 +53,6 @@ module.exports = {
           `${prefix.source}:\\s(${jiraUrl.source}|\\[\?${ticket.source}\\]\?)(\\s.*)?`,
           'g',
         );
-
-        console.log({ regex });
 
         for (const comment of context.getSourceCode().getAllComments()) {
           const value = comment.value.trimStart();

--- a/src/rules/no-jira-todo/no-jira-todo.js
+++ b/src/rules/no-jira-todo/no-jira-todo.js
@@ -1,0 +1,79 @@
+/*
+# What is this?
+
+Builds on eslint-plugin-react/forbid-component-props and extends to allow and Allow List to be provided as a regex.
+
+Aside from providing an `allowedForRegex` option the implementation remains the same. A `disallowedForRegex` is not provided as no use case currently exists, so we avoid the extra complexity.
+
+https://github.com/jsx-eslint/eslint-plugin-react/blob/9f4b2b96d92bf61ae61e8fc88c413331efe6f0da/lib/rules/forbid-component-props.js#L2
+
+An issue has been raised with eslint-plugin-react to ask for this feature, if provided we should switch to:
+- https://github.com/jsx-eslint/eslint-plugin-react/issues/3686
+
+
+# Why do we need a custom rule?
+
+We use this linting specifically for linting on className usage. This has been seen to cause specificity problems when working in a code-split app.
+
+Our allowlist for the medium to long term will include Bpk* components, and backpack-component-icon Icons. The former is a static list, which could be maintained in an .eslintrc with minimum toil.
+
+However, when used with the `withDefaultProps` HOC that Backpack provide the names become more dynamic and more toil to maintain. Additionally, and significantly, Icons are also much higher volume, and have dynamic names.
+
+Maintaining a list of components and managing contributors confusion is higher toil than maintaining this custom rule.
+*/
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+const messages = {
+  'todo-error': 'All TODO comments must have a JIRA ticket',
+};
+
+const verifyCommentPrefix = (comment) =>
+  ['TODO', 'FIXME', '@TODO', '@FIXME'].find((prefix) =>
+    comment.startsWith(prefix),
+  );
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'All TODO comments must have a linked JIRA ticket',
+      category: 'Best Practices',
+      recommended: 'error',
+      url: 'https://github.com/Skyscanner/eslint-plugin-rules#no-jira-todo',
+    },
+    messages,
+    type: 'suggestion',
+    schema: [],
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      Program() {
+        const prefix = new RegExp('@?(TODO|FIXME)');
+        const ticket = new RegExp('[A-Z]{2,255}-(\\d|X){2,8}');
+        const jiraUrl = new RegExp(
+          `https://skyscanner.atlassian.net/browse/${ticket.source}`,
+        );
+        const regex = new RegExp(
+          `${prefix.source}:\\s(${jiraUrl.source}|\\[${ticket.source}\\])(\\s.*)?`,
+          'g',
+        );
+
+        for (const comment of context.getSourceCode().getAllComments()) {
+          const value = comment.value.trimStart();
+
+          if (verifyCommentPrefix(value) && !regex.test(value)) {
+            context.report({
+              node: comment,
+              messageId: 'todo-error',
+              fix: (fixer) =>
+                fixer.replaceText(comment, '// TODO: [JIRA-XXXX]'),
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/src/rules/no-jira-todo/no-jira-todo.test.js
+++ b/src/rules/no-jira-todo/no-jira-todo.test.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2023-present Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const { RuleTester } = require('eslint');
+
+const rule = require('./no-jira-todo');
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true,
+  },
+};
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('no-jira-todo', rule, {
+  valid: [
+    'const variable = "Non comment"',
+    '// TODO: [WALL-1234] description',
+    '// TODO: [JIRA-XXXX] fixed',
+    '// FIXME: [CASTLE-5678]',
+    '// FIXME: [WOM-2468] comment',
+    '// @TODO: [WALL-1234] description',
+    '// @FIXME: [WALL-1234] description',
+    '// TODO: https://skyscanner.atlassian.net/browse/SHIBA-1234 description',
+    '// @FIXME: https://skyscanner.atlassian.net/browse/WOODPECKER-1010 description',
+    'const regex = new RegExp("expression", "i"); // TODO: [JIRA-4321] comment',
+  ],
+  invalid: [
+    {
+      code: '// TODO: WALL-1234 description',
+      errors: [{ messageId: 'todo-error' }],
+      output: '// TODO: [JIRA-XXXX]',
+    },
+    {
+      code: '// TODO: please fail',
+      errors: [{ messageId: 'todo-error' }],
+      output: '// TODO: [JIRA-XXXX]',
+    },
+    {
+      code: '// TODO: this should also fail WALL-1234',
+      errors: [{ messageId: 'todo-error' }],
+      output: '// TODO: [JIRA-XXXX]',
+    },
+    {
+      code: '// FIXME another fail WALL-1234',
+      errors: [{ messageId: 'todo-error' }],
+      output: '// TODO: [JIRA-XXXX]',
+    },
+    {
+      code: '// @FIXME and this too [WALL-1234]',
+      errors: [{ messageId: 'todo-error' }],
+      output: '// TODO: [JIRA-XXXX]',
+    },
+    {
+      code: '// @TODO: https://skyscanner.atlassian.net/browse/not-a-ticket',
+      errors: [{ messageId: 'todo-error' }],
+      output: '// TODO: [JIRA-XXXX]',
+    },
+  ],
+});

--- a/src/rules/no-jira-todo/no-jira-todo.test.js
+++ b/src/rules/no-jira-todo/no-jira-todo.test.js
@@ -31,21 +31,18 @@ ruleTester.run('no-jira-todo', rule, {
   valid: [
     'const variable = "Non comment"',
     '// TODO: [WALL-1234] description',
+    '// TODO: DINGO-123 description',
     '// TODO: [JIRA-XXXX] fixed',
     '// FIXME: [CASTLE-5678]',
     '// FIXME: [WOM-2468] comment',
     '// @TODO: [WALL-1234] description',
     '// @FIXME: [WALL-1234] description',
     '// TODO: https://skyscanner.atlassian.net/browse/SHIBA-1234 description',
+    '// TODO: https://atlassian-upgrade.net/browse/WALL-1234',
     '// @FIXME: https://skyscanner.atlassian.net/browse/WOODPECKER-1010 description',
     'const regex = new RegExp("expression", "i"); // TODO: [JIRA-4321] comment',
   ],
   invalid: [
-    {
-      code: '// TODO: WALL-1234 description',
-      errors: [{ messageId: 'todo-error' }],
-      output: '// TODO: [JIRA-XXXX]',
-    },
     {
       code: '// TODO: please fail',
       errors: [{ messageId: 'todo-error' }],

--- a/src/rules/no-jira-todo/no-jira-todo.test.js
+++ b/src/rules/no-jira-todo/no-jira-todo.test.js
@@ -41,6 +41,9 @@ ruleTester.run('no-jira-todo', rule, {
     '// TODO: https://atlassian-upgrade.net/browse/WALL-1234',
     '// @FIXME: https://skyscanner.atlassian.net/browse/WOODPECKER-1010 description',
     'const regex = new RegExp("expression", "i"); // TODO: [JIRA-4321] comment',
+    `// TODO: ST-123 first of multiple TODOs
+    const { locale } = context[requestContextParameters.CULTURE];
+    // TODO: DINGO-123 another TODO`,
   ],
   invalid: [
     {


### PR DESCRIPTION
Was looking to replicate a similar rule to Banana in Falcon to have a JIRA ticket linked to every TODO comment

Banana: https://github.skyscannertools.net/dingo/banana/blob/main/packages/eslint-plugin-custom-linting/lib/rules/jira-ticket-todo-comment.js
Falcon PR: https://github.skyscannertools.net/martech/falcon/pull/5607

@dominicfraser suggested that this may be a good addition to make available to all of the Skyscanner teams, so looking to add here in order to do so
https://github.skyscannertools.net/martech/falcon/pull/5607#discussion_r941687

### Changes
- Creates a rule to ensure all TODO comments have a linked JIRA ticket
- Merges format of Banana and proposed Falcon
- Allows for prefixes of `TODO`/`FIXME`/`@TODO`/`@FIXME`
- Allows for JIRA ticket references to be URL or just ticket reference
- Allows for optional description text