### PR TITLE
Remove `no-jira-todo` fixer

### DIFF
--- a/src/rules/no-jira-todo/README.md
+++ b/src/rules/no-jira-todo/README.md
@@ -32,9 +32,3 @@ Examples of invalid comments:
 // @FIXME description of the change needed WALL-1234
 // @TODO: https://skyscanner.atlassian.net/browse/not-a-ticket
 ```
-
-If an invalid `TODO` comment is recognised, there is a auto fix available to update the comment to the format. This should be updated with the ticket and description. This is provided in the format:
-
-```tsx
-// TODO: [JIRA-XXX]
-```

--- a/src/rules/no-jira-todo/no-jira-todo.js
+++ b/src/rules/no-jira-todo/no-jira-todo.js
@@ -39,7 +39,6 @@ module.exports = {
     messages,
     type: 'suggestion',
     schema: [],
-    fixable: 'code',
   },
   create(context) {
     return {

--- a/src/rules/no-jira-todo/no-jira-todo.js
+++ b/src/rules/no-jira-todo/no-jira-todo.js
@@ -60,8 +60,6 @@ module.exports = {
             context.report({
               node: comment,
               messageId: 'todo-error',
-              fix: (fixer) =>
-                fixer.replaceText(comment, '// TODO: [JIRA-XXXX]'),
             });
           }
         }

--- a/src/rules/no-jira-todo/no-jira-todo.test.js
+++ b/src/rules/no-jira-todo/no-jira-todo.test.js
@@ -49,27 +49,22 @@ ruleTester.run('no-jira-todo', rule, {
     {
       code: '// TODO: please fail',
       errors: [{ messageId: 'todo-error' }],
-      output: '// TODO: [JIRA-XXXX]',
     },
     {
       code: '// TODO: this should also fail WALL-1234',
       errors: [{ messageId: 'todo-error' }],
-      output: '// TODO: [JIRA-XXXX]',
     },
     {
       code: '// FIXME another fail WALL-1234',
       errors: [{ messageId: 'todo-error' }],
-      output: '// TODO: [JIRA-XXXX]',
     },
     {
       code: '// @FIXME and this too [WALL-1234]',
       errors: [{ messageId: 'todo-error' }],
-      output: '// TODO: [JIRA-XXXX]',
     },
     {
       code: '// @TODO: https://skyscanner.atlassian.net/browse/not-a-ticket',
       errors: [{ messageId: 'todo-error' }],
-      output: '// TODO: [JIRA-XXXX]',
     },
   ],
 });


### PR DESCRIPTION
Having the fixer on the `no-jira-todo` rule could lead to the accidental destruction of TODO comments, especially where lint fixes were applied on save. This also encouraged the use of the JIRA-XX escape hatch, meaning a valid ticket was rarely assigned to TODOs.