### PR TITLE
[THES-939] Linter rule to prohibit unsupported .at() usage

### DIFF
--- a/src/rules/no-at/no-at.js
+++ b/src/rules/no-at/no-at.js
@@ -14,18 +14,31 @@
  * limitations under the License.
  */
 
-const noAxios = require('./src/rules/no-axios/no-axios');
-const noEnum = require('./src/rules/no-enum/no-enum');
-const forbidComponentProps = require('./src/rules/forbid-component-props/forbid-component-props');
-const noJiraTodo = require('./src/rules/no-jira-todo/no-jira-todo');
-const noAt = require('./src/rules/no-at/no-at');
-
 module.exports = {
-  rules: {
-    'no-axios': noAxios,
-    'no-enum': noEnum,
-    'forbid-component-props': forbidComponentProps,
-    'no-jira-todo': noJiraTodo,
-    'no-at': noAt,
+  create: (context) => ({
+    CallExpression: (node) => {
+      const callee = node.callee;
+      if (
+        callee.type === 'MemberExpression' &&
+        !callee.computed &&
+        callee.property &&
+        callee.property.name === 'at'
+      ) {
+        context.report({
+          node: callee.property,
+          messageId: 'disallow',
+        });
+      }
+    },
+  }),
+  meta: {
+    docs: {
+      description:
+        'Disallow usage of `.at()` due to Safari <15.4 incompatibility',
+    },
+    messages: {
+      disallow:
+        'Usage of ".at()" is not supported in Safari <15.4. Use bracket indexing instead.',
+    },
   },
 };

--- a/src/rules/no-at/no-at.test.js
+++ b/src/rules/no-at/no-at.test.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2023-present Skyscanner Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { RuleTester } = require('eslint');
+
+const noAt = require('./no-at');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-at', noAt, {
+  valid: [
+    {
+      code: 'foo[0];',
+    },
+    {
+      code: 'foo[foo.length - 1];',
+    },
+    {
+      code: 'foo.method();',
+    },
+  ],
+  invalid: [
+    {
+      code: 'foo.at(1);',
+      errors: [{ messageId: 'disallow' }],
+    },
+    {
+      code: '"foo".at(1);',
+      errors: [{ messageId: 'disallow' }],
+    },
+    {
+      code: 'foo?.at(1);',
+      errors: [{ messageId: 'disallow' }],
+    },
+    {
+      code: 'foo.at?.(1)',
+      errors: [{ messageId: 'disallow' }],
+    },
+    {
+      code: 'foo.method().at?.(1)',
+      errors: [{ messageId: 'disallow' }],
+    },
+  ],
+});


### PR DESCRIPTION
This PR introduces a linter rule to prohibit usage of `at()` due to its lack of support in Safari <15.4 which is one of our supported browsers.

